### PR TITLE
Add `useScroll` utility hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,19 @@ function App() {
   </Show>
 </Presence>
 ```
+
+## Scroll-Linked Animations
+
+`useScroll` provides reactive values based on Motion One's original [`scroll`](https://motion.dev/docs/scroll) function.
+
+```ts
+import { useScroll } from "solid-motionone"
+
+// ...
+
+const { time, scrollX, scrollY } = useScroll()
+
+createEffect(() => console.log(scrollY.progress))
+```
+
+These values can be used in coordination with Motion animation properties to create scroll-linked/parallax animations.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 export * from "./types.js"
 export {Motion} from "./motion.jsx"
 export {Presence, PresenceContext} from "./presence.jsx"
-export {createMotion, motion} from "./primitives.js"
+export {createMotion, motion, useScroll} from "./primitives.js"

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,8 +1,17 @@
-import {createMotionState, createStyles, MotionState, style} from "@motionone/dom"
+import {
+	AxisScrollInfo,
+	createMotionState,
+	createStyles,
+	MotionState,
+	style,
+	scroll,
+	ScrollOptions,
+} from "@motionone/dom"
 import {Accessor, createEffect, onCleanup, useContext} from "solid-js"
 
 import {PresenceContext, PresenceContextState} from "./presence.jsx"
 import {Options} from "./types.js"
+import {createStore, produce} from "solid-js/store"
 
 /** @internal */
 export function createAndBindMotionState(
@@ -63,6 +72,25 @@ export function createMotion(
 	}
 
 	return state
+}
+
+type MotionOneScrollContext = {
+	scrollX?: AxisScrollInfo
+	scrollY?: AxisScrollInfo
+}
+export function useScroll(options?: ScrollOptions): MotionOneScrollContext {
+	const [scrollStore, setScrollStore] = createStore<MotionOneScrollContext>()
+
+	scroll(({x, y}) => {
+		setScrollStore(
+			produce(scrollStore => {
+				scrollStore.scrollX = x
+				scrollStore.scrollY = y
+			}),
+		)
+	}, options)
+
+	return scrollStore
 }
 
 /**

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -7,7 +7,7 @@ import {
 	scroll,
 	ScrollOptions,
 } from "@motionone/dom"
-import {Accessor, createEffect, onCleanup, useContext} from "solid-js"
+import {Accessor, batch, createEffect, createSignal, onCleanup, onMount, useContext} from "solid-js"
 
 import {PresenceContext, PresenceContextState} from "./presence.jsx"
 import {Options} from "./types.js"
@@ -74,23 +74,42 @@ export function createMotion(
 	return state
 }
 
-type MotionOneScrollContext = {
-	scrollX?: AxisScrollInfo
-	scrollY?: AxisScrollInfo
-}
-export function useScroll(options?: ScrollOptions): MotionOneScrollContext {
-	const [scrollStore, setScrollStore] = createStore<MotionOneScrollContext>()
+export function useScroll(options?: ScrollOptions): {
+	time: Accessor<number>
+	scrollX: AxisScrollInfo
+	scrollY: AxisScrollInfo
+} {
+	const [time, setTime] = createSignal(0)
+	const [scrollX, setScrollX] = createStore<AxisScrollInfo>({
+		current: 0,
+		offset: [],
+		progress: 0,
+		scrollLength: 0,
+		velocity: 0,
+		targetOffset: 0,
+		targetLength: 0,
+		containerLength: 0,
+	})
+	const [scrollY, setScrollY] = createStore<AxisScrollInfo>({
+		current: 0,
+		offset: [],
+		progress: 0,
+		scrollLength: 0,
+		velocity: 0,
+		targetOffset: 0,
+		targetLength: 0,
+		containerLength: 0,
+	})
 
-	scroll(({x, y}) => {
-		setScrollStore(
-			produce(scrollStore => {
-				scrollStore.scrollX = x
-				scrollStore.scrollY = y
-			}),
-		)
-	}, options)
+	onMount(() =>
+		scroll(({time, x, y}) => {
+			setTime(time)
+			setScrollX(x)
+			setScrollY(y)
+		}, options),
+	)
 
-	return scrollStore
+	return {time, scrollX, scrollY}
 }
 
 /**


### PR DESCRIPTION
This PR just adds `useScroll` as a utility function to get reactive updates from motionone's [scroll](https://motion.dev/docs/scroll) listener. I tested it in browser and reactivity is working.

I haven't really contributed to or created any TS/Solid libraries before so I am sure there are some things that might need changing. It would be great if someone more experienced could do a proper review to make sure the code is idiomatic and functional.

Relevant issue: #8