### PR TITLE
Prevent Presence component to crash if mountedStates does not contain the provided element

### DIFF
--- a/src/presence.tsx
+++ b/src/presence.tsx
@@ -55,7 +55,7 @@ export const Presence: FlowComponent<{
 							onExit(el, done) {
 								batch(() => {
 									setMount(false)
-									;(mountedStates.get(el)?.getOptions() as Options).exit
+									;(mountedStates.get(el)?.getOptions() as Options)?.exit
 										? el.addEventListener("motioncomplete", done)
 										: done()
 								})


### PR DESCRIPTION
I had the situation where `mountedStates.get(el)` was actually undefined. That throws and breaks the app since the provided guard is not sufficient to prevent the access to `undefined.exit`. 

Please consider adding the extra optional chaining operator to prevent such crashes.