### PR TITLE
fix: Options can be undefined sometimes which crash the component

### DIFF
--- a/src/presence.tsx
+++ b/src/presence.tsx
@@ -53,7 +53,7 @@ export const Presence: FlowComponent<{
 							onExit(el, done) {
 								batch(() => {
 									setMount(false)
-									mountedStates.get(el)?.getOptions().exit
+									mountedStates.get(el)?.getOptions()?.exit
 										? el.addEventListener("motioncomplete", done)
 										: done()
 								})


### PR DESCRIPTION
I've ran into this issue a few times before. It's not just when you're missing an `exit` prop on the child component, it can happen randomly at times that the whole Presence component errors out due `Cannot read properties of undefined (reading `exit`)`